### PR TITLE
Implement progress reporting for commandline version

### DIFF
--- a/src/commandline.cc
+++ b/src/commandline.cc
@@ -47,6 +47,7 @@ show_help (char **argv)
           "Shotdetect (IRI - johmathe - $Id: main.cpp 164 2007-10-13 23:53:21Z johmathe $)\n"
           "-h           : show this help\n"
           "-i file      : input file path\n"
+          "-p           : output progress report information\n"
           "-o path      : output path\n"
           "-s threshold : threshold\n"
           "-w           : generate xml of waveform\n"
@@ -72,7 +73,7 @@ main (int argc, char **argv)
   f.threshold=60;
 
   for (;;) {
-    int c = getopt (argc, argv, "?ht:i:o:s:flwvmr");
+    int c = getopt (argc, argv, "?ht:i:o:s:flpwvmr");
 
     if (c < 0) {
       break;
@@ -102,6 +103,10 @@ main (int argc, char **argv)
       /* generer l'image en miniature */
     case 'm':
       f.set_thumb(true);
+      break;
+
+    case 'p':
+      f.set_progress(true);
       break;
 
       /* generer le xml pour les donnees video */

--- a/src/film.cc
+++ b/src/film.cc
@@ -36,6 +36,13 @@ extern "C" {
 
 int film::idfilm = 0;
 
+void film::log_progress(string type, int position, int total)
+{
+  if (this->get_progress()) {
+    cerr << type << " " << position << " " << total << endl;
+  }
+}
+
 void film::do_stats(int frame_number)
 {
   double perctmp = percent;
@@ -138,9 +145,7 @@ void film::CompareFrame (AVFrame * pFrame, AVFrame * pFramePrev)
     s.msbegin = int ((frame_number * 1000) / fps);
     s.myid = shots.back ().myid + 1;
 
-#ifdef DEBUG
-    cerr << "Shot log :: " << s.msbegin << endl;
-#endif
+    this->log_progress("shot", s.msbegin, duration.mstotal);
 
     /*
      * Convert to ms
@@ -397,6 +402,10 @@ int film::process ()
       if (frameFinished) {
         frame_number = pCodecCtx->frame_number; // Current frame number
 
+        // Report progress information every 100 frames
+        if (frame_number % 100 == 0) {
+          this->log_progress("progress", int((frame_number * 1000) / fps), duration.mstotal);
+        }
         // Convert the image into RGB24
         if (! img_convert_ctx) {
           img_convert_ctx = sws_getContext(width, height, pCodecCtx->pix_fmt,

--- a/src/film.h
+++ b/src/film.h
@@ -187,6 +187,8 @@ public:
   double percent;
   /* Showing state started */
   bool show_started;
+  /* Output progress information */
+  bool progress;
   xml *x;
   bool display;
 
@@ -194,6 +196,7 @@ public:
   void process_audio ();
   void shotlog(string message);
   void create_main_dir(void);
+  void log_progress(string message, int position, int total);
 
   /* Constructor */
   film ();
@@ -241,6 +244,9 @@ public:
   inline void set_title(string title) {
     this->title = title;
   };
+  inline void set_progress(bool progress) {
+    this->progress = progress;
+  };
 
   inline bool get_first_img(void) {
     return this->first_img_set ;
@@ -268,6 +274,9 @@ public:
   };
   inline double get_fps(void)     {
     return this->fps ;
+  };
+  inline bool get_progress(void)  {
+    return this->progress ;
   };
 
 };


### PR DESCRIPTION
Specifying -p will output information on stderr, in the form

progress current_position_in_ms total_duration_in_ms
shot current_position_in_ms total_duration_in_ms
