### PR TITLE
fix: add missing bundle destination for Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ ENDIF()
 # Taken from official documentation (http://www.cmake.org/cmake/help/cmake2.6docs.html#command:install)
 install( 
     TARGETS ${TARGETS_TO_INSTALL}
+    BUNDLE  DESTINATION .
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib/static


### PR DESCRIPTION
Set the BUNDLE DESTINATION to cwd.

The compiled application bundle (.app) will be installed here after it's compiled.

When unset, builds would fail with this error:

```
CMake Error at CMakeLists.txt:209 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "shotdetect-gui".
```

Build environment:

```
CMake: 2.8.11.2
OS X: 10.8.4-x86_64
```
