### PR TITLE
Pass just filename to xml::write_data

### DIFF
--- a/src/commandline.cc
+++ b/src/commandline.cc
@@ -210,8 +210,7 @@ main (int argc, char **argv)
 
   f.shotlog("Processing movie.");
   f.process ();
-  string xml_path  = f.global_path;
-  xml_path += "/result.xml";
+  string xml_path  = "result.xml";
   f.x->write_data (xml_path);
   /*string finished_path = f.global_path;
   finished_path += "/finished";


### PR DESCRIPTION
This is one possible fix for issue #7, I don't think the filename should be hardcoded in `write_data`, but I am not aware of your design goals.