### PR TITLE
Fix buffer overflow in graph timecode generation

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -213,7 +213,7 @@ graph::draw_canvas (gdImagePtr im, string title, graph_color colorset)
   int tick_length;
   bool is_second, is_minute, is_hour;
   int hour, minute, second, frame;
-  char timecode[10];
+  char timecode[11];
   int frames;
 
   gdImageFilledRectangle (im, 0, 0, xsize, ysize, colorset.background);


### PR DESCRIPTION
When option `-c` is enabled (print timecode on x-axis in graph) and Shotdetect is compiled with any compiler optimization (`-O1`) and higher, the program always crashes with segmentation fault or buffer overflow.

The source of the problem is the string `char timecode[10]` – the resulting string from `sprintf` is exactly 10 characters long, leaving no space for null terminator.