### PR TITLE
Support middle frames, compile in Release mode, fix an off-by-one bug in image.cc

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -6,12 +6,12 @@ case "$1" in
     gui)
         mkdir -p build
         cd build
-        cmake .. && make
+        cmake -D CMAKE_BUILD_TYPE=Release .. && make
     ;;
     cmd)
         mkdir -p build
         cd build
-        cmake -D USE_WXWIDGETS:BOOL=OFF .. && make
+        cmake -D CMAKE_BUILD_TYPE=Release -D USE_WXWIDGETS:BOOL=OFF .. && make
     ;;
     all)
         mkdir -p build

--- a/compile.sh
+++ b/compile.sh
@@ -29,4 +29,4 @@ case "$1" in
         echo "SYNTAX: $0 (gui|cmd|all)"
         echo ""
         echo ""
-esac 
+esac

--- a/src/commandline.cc
+++ b/src/commandline.cc
@@ -50,6 +50,7 @@ void show_help(char **argv) {
       "-h           : show this help\n"
       "-n           : commandline mode (disable GUI)\n"
       "-s threshold : threshold (Default=%d)\n"
+      "-d duration  : maximum shot duration in milliseconds (Default=%d)\n"
       "-i file      : input file path\n"
       "-o path      : output path\n"
       "-y year      : set the year\n"
@@ -59,10 +60,11 @@ void show_help(char **argv) {
       "-v           : generate xml of video infos\n"
       "-f           : generate first image for each shot\n"
       "-l           : generate last image for each shot\n"
+      "-q           : generate middle image for each shot\n"
       "-m           : generate the thumbnail image\n"
       "-r           : generate the images in native resolution\n"
       "-c           : print timecode on x-axis in graph\n",
-      g_APP_VERSION, argv[0], DEFAULT_THRESHOLD);
+      g_APP_VERSION, argv[0], DEFAULT_THRESHOLD, DEFAULT_MAX_SHOT_MS_DURATION);
 }
 
 int main(int argc, char **argv) {
@@ -77,8 +79,8 @@ int main(int argc, char **argv) {
   extern char *optarg;
   extern int optind, opterr, optopt;
 
-  // Initialize threshold to a sensible default value
   f.threshold = DEFAULT_THRESHOLD;
+  f.max_shot_ms_duration = DEFAULT_MAX_SHOT_MS_DURATION;
 
   // Set default settings:
   f.set_draw_rgb_graph(true);
@@ -86,7 +88,7 @@ int main(int argc, char **argv) {
   f.set_draw_yuv_graph(false);  // YUV graph is still disabled, until it works.
 
   for (;;) {
-    int c = getopt(argc, argv, "?ht:y:i:o:a:x:s:flwvmrc");
+    int c = getopt(argc, argv, "?ht:y:i:o:a:x:s:d:flqwvmrc");
 
     if (c < 0) {
       break;
@@ -107,6 +109,10 @@ int main(int argc, char **argv) {
       /* Draw last image of scene cut? */
       case 'l':
         f.set_last_img(true);
+        break;
+
+      case 'q':
+        f.set_middle_img(true);
         break;
 
       /* Generate images with native resolution? */
@@ -132,6 +138,11 @@ int main(int argc, char **argv) {
       /* Set the threshold */
       case 's':
         f.set_threshold(atoi(optarg));
+        break;
+
+      /* Set max shot ms duration */
+      case 'd':
+        f.set_max_shot_ms_duration(atoi(optarg));
         break;
 
       /* Embed timecode in graph  */

--- a/src/film.cc
+++ b/src/film.cc
@@ -407,10 +407,10 @@ int film::process() {
     /*
      * Allocate current and previous video frames
      */
-    pFrame = av_frame_alloc();
+    pFrame = avcodec_alloc_frame();
     // RGB:
-    pFrameRGB = av_frame_alloc();      // current frame
-    pFrameRGBprev = av_frame_alloc();  // previous frame
+    pFrameRGB = avcodec_alloc_frame();      // current frame
+    pFrameRGBprev = avcodec_alloc_frame();  // previous frame
 
 
     /*
@@ -480,7 +480,7 @@ int film::process() {
                   pCodecCtx->height, pFrameRGB->data, pFrameRGB->linesize);
 
         /* Push new RBG frame into list front */
-        AVFrame* pTempFrame = av_frame_alloc();
+        AVFrame* pTempFrame = avcodec_alloc_frame();
         avpicture_alloc((AVPicture*) pTempFrame, PIX_FMT_RGB24, width, height);
         av_picture_copy((AVPicture*) pTempFrame, (AVPicture *)pFrameRGB,
                         PIX_FMT_RGB24, width, height);
@@ -596,7 +596,7 @@ void film::process_audio() {
   len = packet.size;
 
   while (len > 0) {
-    this->audio_buf = av_frame_alloc();
+    this->audio_buf = avcodec_alloc_frame();
     // (short *) av_fast_realloc (this->audio_buf, &samples_size, FFMAX
     // (packet.size, AVCODEC_MAX_AUDIO_FRAME_SIZE));
     data_size = samples_size;

--- a/src/image.cc
+++ b/src/image.cc
@@ -110,7 +110,7 @@ int image::SaveFrame(AVFrame *pFrame, int frame_number) {
   }
 
   /* Pad numbers to constant string width: */
-  char s_id[5];
+  char s_id[6];
   char s_frame_number[9];
 
   sprintf(s_id, "%05d", id);
@@ -123,9 +123,12 @@ int image::SaveFrame(AVFrame *pFrame, int frame_number) {
     if (this->type == BEGIN)
       str << f->alphaid << "/thumbs/" << f->alphaid << "_" << s_id << "-"
           << s_frame_number << "_in.jpg";
-    else
+    else if (this->type == END)
       str << f->alphaid << "/thumbs/" << f->alphaid << "_" << s_id << "-"
           << s_frame_number << "_out.jpg";
+    else if (this->type == MIDDLE)
+      str << f->alphaid << "/thumbs/" << f->alphaid << "_" << s_id << "-"
+          << s_frame_number << "_middle.jpg";
 
     thumb = str.str();
     str.str("");
@@ -149,9 +152,13 @@ int image::SaveFrame(AVFrame *pFrame, int frame_number) {
     if (this->type == BEGIN)
       str << f->alphaid << "/shots/" << f->alphaid << "_" << s_id << "-"
           << s_frame_number << "_in.jpg";
-    else
+    else if (this->type == END)
       str << f->alphaid << "/shots/" << f->alphaid << "_" << s_id << "-"
           << s_frame_number << "_out.jpg";
+    else if (this->type == MIDDLE) {
+      str << f->alphaid << "/shots/" << f->alphaid << "_" << s_id << "-"
+          << s_frame_number << "_middle.jpg";
+    }
 
     img = str.str();
     str.str("");
@@ -173,7 +180,7 @@ int image::SaveFrame(AVFrame *pFrame, int frame_number) {
   return 0;
 }
 
-image::image(film *_f, int _width, int _height, int _id, bool _type,
+image::image(film *_f, int _width, int _height, int _id, short _type,
              bool _thumb_set, bool _shot_set)
     : shot_set(_shot_set),
       thumb_set(_thumb_set),

--- a/src/image.h
+++ b/src/image.h
@@ -34,8 +34,9 @@ extern "C" {
 #include <wx/wx.h>
 #endif
 
-#define BEGIN true
-#define END false
+#define BEGIN 0x00
+#define END 0x01
+#define MIDDLE 0x02
 using namespace std;
 
 class conf;
@@ -54,10 +55,10 @@ class image {
   string thumb;
   string img;
   int id;
-  bool type;  // BEGIN || END
+  short type;  // BEGIN || END || MIDDLE
   int SaveFrame(AVFrame *pFrame, int frame_number);
   int create_img_dir();
-  image(film *, int, int, int, bool, bool, bool);
+  image(film *, int, int, int, short, bool, bool);
 };
 
 #endif /* !__IMAGE_H__ */

--- a/src/main.cc
+++ b/src/main.cc
@@ -47,6 +47,7 @@ void show_help(char **argv) {
       "-h           : show this help\n"
       "-n           : commandline mode (disable GUI)\n"
       "-s threshold : threshold (Default=%d)\n"
+      "-d duration  : max shot duration in milliseconds (Default=%d)\n"
       "-i file      : input file path\n"
       "-o path      : output path\n"
       "-y year      : set the year\n"
@@ -56,10 +57,11 @@ void show_help(char **argv) {
       "-v           : generate xml of video infos\n"
       "-f           : generate first image for each shot\n"
       "-l           : generate last image for each shot\n"
+      "-q           : generate middle image for each shot\n"
       "-m           : generate the thumbnail image\n"
       "-r           : generate the images in native resolution\n"
       "-c           : print timecode on x-axis in graph\n",
-      g_APP_VERSION, argv[0], DEFAULT_THRESHOLD);
+      g_APP_VERSION, argv[0], DEFAULT_THRESHOLD, DEFAULT_MAX_SHOT_MS_DURATION);
 }
 
 int main(int argc, char **argv) {
@@ -74,11 +76,11 @@ int main(int argc, char **argv) {
   extern char *optarg;
   extern int optind, opterr, optopt;
 
-  // Initialize threshold to a sensible default value
   f.threshold = DEFAULT_THRESHOLD;
+  f.max_shot_ms_duration = DEFAULT_MAX_SHOT_MS_DURATION;
 
   for (;;) {
-    int c = getopt (argc, argv, "?hnt:y:i:o:a:x:s:fTlwvmrc");
+    int c = getopt (argc, argv, "?hnt:y:i:o:a:x:s:d:fqTlwvmrc");
 
     if (c < 0) {
       break;
@@ -99,6 +101,11 @@ int main(int argc, char **argv) {
       /* Draw last image of scene cut? */
       case 'l':
         f.set_last_img(true);
+        break;
+
+      /* Draw middle image of scene cut? */
+      case 'q':
+        f.set_middle_img(true);
         break;
 
       /* Generate images with native resolution? */
@@ -126,19 +133,23 @@ int main(int argc, char **argv) {
         f.set_threshold(atoi(optarg));
         break;
 
+      /* Set maximum shot ms duration */
+      case 'd':
+        f.set_max_shot_ms_duration(atoi(optarg));
+
       /* Embed timecode in graph  */
       case 'c':
         f.set_show_timecode(true);
         break;
       /* Set the title */
-    case 't':
-      f.set_title(optarg);
-      break;
+      case 't':
+        f.set_title(optarg);
+        break;
 
       /* Embed timecode in graph  */
-    case 'T':
-      f.set_show_timecode(true);
-      break;
+      case 'T':
+        f.set_show_timecode(true);
+        break;
 
       /* Id for path creation */
       case 'a':

--- a/src/ui/dialog_shotdetect.cc
+++ b/src/ui/dialog_shotdetect.cc
@@ -98,6 +98,8 @@ DialogShotDetect::DialogShotDetect(wxWindow *parent, int id,
   checkbox_1->SetValue(true);
   checkbox_2 = new wxCheckBox(this, -1, wxT("Last image"));
   checkbox_2->SetValue(true);
+  checkbox_3 = new wxCheckBox(this, -1, wxT("Middle image"));
+  checkbox_3->SetValue(true);
   hframe = new HelpFrame(this, -1, _T ("About Shotdetect"));
   progress_global->SetValue(0);
   progress_local->SetValue(0);
@@ -134,10 +136,10 @@ void DialogShotDetect::FinProcess(wxCommandEvent &event) {
 void DialogShotDetect::AjouterFichier(wxCommandEvent &event) {
   wxFileDialog dialog(
       this, _T ("Open file for an analyse"), wxEmptyString, wxEmptyString,
-#ifdef __WXMOTIF__ \
+#ifdef __WXMOTIF__
     _T ("Media files (*.avi;*.flv;*.mp4;*.mpg;*.mov;*.mp3;*.wav)|*.avi;*.flv;*.mp4;*.mpg;*.mov;*.mp3;*.wav")
 #else
-                       _T ("Media files (*.avi;*.flv;*.mp4;*.mpg;*.mov;*.mp3;*.wav)|*.avi;*.flv;*.mp4;*.mpg;*.mov;*.mp3;*.wav")
+    _T ("Media files (*.avi;*.flv;*.mp4;*.mpg;*.mov;*.mp3;*.wav)|*.avi;*.flv;*.mp4;*.mpg;*.mov;*.mp3;*.wav")
 #endif
       );
   dialog.SetDirectory(wxGetHomeDir());
@@ -349,6 +351,7 @@ void DialogShotDetect::do_layout() {
    */
   sizer_check->Add(checkbox_1, 1, wxADJUST_MINSIZE, 0);
   sizer_check->Add(checkbox_2, 1, wxADJUST_MINSIZE, 0);
+  sizer_check->Add(checkbox_3, 1, wxADJUST_MINSIZE, 0);
   sizer_horiz_3->Add(sizer_seuil, 1, wxADJUST_MINSIZE | wxALIGN_RIGHT, 0);
   sizer_horiz_3->Add(sizer_offset, 1, wxADJUST_MINSIZE, 0);
   sizer_horiz_3->Add(sizer_check, 0, wxADJUST_MINSIZE, 0);

--- a/src/ui/dialog_shotdetect.h
+++ b/src/ui/dialog_shotdetect.h
@@ -97,6 +97,7 @@ class DialogShotDetect : public wxDialog {
   wxListCtrl *list_films;
   wxCheckBox *checkbox_1;
   wxCheckBox *checkbox_2;
+  wxCheckBox *checkbox_3;
   void AjouterFichier(wxCommandEvent &event);   // wxGlade: <event_handler>
   void EnleverFichier(wxCommandEvent &event);   // wxGlade: <event_handler>
   void ViderListe(wxCommandEvent &event);       // wxGlade: <event_handler>

--- a/src/version.cc.in
+++ b/src/version.cc.in
@@ -11,5 +11,5 @@
 
 const char g_GIT_SHA1[] = GIT_SHA1;
 const char g_GIT_SHA1_SHORT[] = GIT_SHA1_SHORT;
-const char g_APP_VERSION[] = "2.0.0-git@GIT_SHA1_SHORT@";
+const char g_APP_VERSION[] = "2.1.0-git@GIT_SHA1_SHORT@";
 


### PR DESCRIPTION
99% of this is Michał Salasa's work. I added some GUI support for the extraction of middle frames. Not sure about it as shotdetect-gui crashes on my machine with

[xcb] Unknown request in queue while dequeuing
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
shotdetect-gui: ../../src/xcb_io.c:179: dequeue_pending_request: Assertion `!xcb_xlib_unknown_req_in_deq' failed.
shotdetect-gui: Fatal IO error 11 (Resource temporarily unavailable) on X server :0.
