### PR TITLE
add check for return value of film::process()

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -213,7 +213,10 @@ int main(int argc, char **argv) {
     f.x = x;
 
     f.shotlog("Processing movie.");
-    f.process();
+    if(f.process() < 0){
+        cerr << "Error in processing the film." << endl;
+        exit(EXIT_FAILURE);
+    }
 
     string xml_path = f.alphaid;
     xml_path += "_";


### PR DESCRIPTION
`film::process()` returns `-1` to indicate an error. This return value is not checked in the `main()` function. This patch adds a check for the return value of `film::process()` and exits the application if the return value is negative.